### PR TITLE
Support 'ON HOST host' in SELECT 

### DIFF
--- a/source/lexer.d
+++ b/source/lexer.d
@@ -7,19 +7,21 @@ enum TokenType
     BY,
     COMMA,
     DESC,
-    SELECT,
     FROM,
-    STAR,
-    WHERE,
-    LPAREN,
-    RPAREN,
-    STRING,
-    NUMERIC,
+    HOST,
     LIMIT,
-    OPEQ,
+    LPAREN,
+    NUMERIC,
+    ON,
     OPAND,
+    OPEQ,
     OPOR,
     ORDER,
+    RPAREN,
+    SELECT,
+    STAR,
+    STRING,
+    WHERE,
 }
 
 struct Token
@@ -66,22 +68,24 @@ struct Token
 immutable TokenType[string] literalTokens;
 static this()
 {
-    literalTokens["from"] = TokenType.FROM;
-    literalTokens["limit"] = TokenType.LIMIT;
-    literalTokens["select"] = TokenType.SELECT;
-    literalTokens["where"] = TokenType.WHERE;
-    literalTokens["order"] = TokenType.ORDER;
-    literalTokens["by"] = TokenType.BY;
-    literalTokens["alter"] = TokenType.ALTER;
-    literalTokens["asc"] = TokenType.ASC;
-    literalTokens["desc"] = TokenType.DESC;
-    literalTokens["*"] = TokenType.STAR;
-    literalTokens[","] = TokenType.COMMA;
     literalTokens["("] = TokenType.LPAREN;
     literalTokens[")"] = TokenType.RPAREN;
+    literalTokens["*"] = TokenType.STAR;
+    literalTokens[","] = TokenType.COMMA;
     literalTokens["="] = TokenType.OPEQ;
+    literalTokens["alter"] = TokenType.ALTER;
     literalTokens["and"] = TokenType.OPAND;
+    literalTokens["asc"] = TokenType.ASC;
+    literalTokens["by"] = TokenType.BY;
+    literalTokens["desc"] = TokenType.DESC;
+    literalTokens["from"] = TokenType.FROM;
+    literalTokens["limit"] = TokenType.LIMIT;
+    literalTokens["on"] = TokenType.ON;
     literalTokens["or"] = TokenType.OPOR;
+    literalTokens["order"] = TokenType.ORDER;
+    literalTokens["select"] = TokenType.SELECT;
+    literalTokens["where"] = TokenType.WHERE;
+    literalTokens["host"] = TokenType.HOST;
 }
 
 class TokenStream
@@ -250,9 +254,10 @@ class TokenStream
             return false;
         }
 
-        bool isValidSymChar(ulong n) {
-          auto c = this.source[n];
-          return isAlphaNum(c) || c == '_' || c == '.';
+        bool isValidSymChar(ulong n)
+        {
+            auto c = this.source[n];
+            return isAlphaNum(c) || c == '_' || c == '.';
         }
 
         auto n = this.peekPos;

--- a/source/parser.d
+++ b/source/parser.d
@@ -67,6 +67,7 @@ struct ParseResult
     Type typ;
     Expr expr;
     TokenAndError[] errors;
+    string host;
 }
 
 struct TokenAndError
@@ -191,11 +192,18 @@ class Parser
 
                 }
             }
+            else if (peekNIsType(0, TokenType.ON) && peekNIsType(1,
+                    TokenType.HOST) && peekNIsType(2, TokenType.STRING))
+            {
+                this.tokens.consume(); //ON
+                this.tokens.consume(); //HOST
+                pr.host = this.tokens.consume().stripQuotes();
+            }
             else
             {
                 auto badToken = this.tokens.consume();
                 pr.errors ~= TokenAndError(badToken,
-                        "expected from, where, or field names in select statement");
+                        "expected from, where, on, or field names in select statement");
             }
         }
     }
@@ -402,7 +410,7 @@ unittest
     auto e = p.parse();
     assert(e.errors.length == 1);
     assert(e.errors[0] == TokenAndError(Token(TokenType.SELECT, 7, "select"),
-            "expected from, where, or field names in select statement"));
+            "expected from, where, on, or field names in select statement"));
 }
 
 unittest


### PR DESCRIPTION
Allows users to point queries towards a specific host instead of always localhost:9200. 

Useful if executing queries on remote hosts or over HTTPS 